### PR TITLE
refactor: remove wildcard imports from test files

### DIFF
--- a/src/integrationTest/java/com/code/agent/presentation/web/WebhookSignatureIntegrationTest.java
+++ b/src/integrationTest/java/com/code/agent/presentation/web/WebhookSignatureIntegrationTest.java
@@ -13,7 +13,10 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 
-import static com.code.agent.infra.github.GitHubConstants.*;
+import static com.code.agent.infra.github.GitHubConstants.HMAC_ALGORITHM;
+import static com.code.agent.infra.github.GitHubConstants.SIGNATURE_PREFIX;
+import static com.code.agent.infra.github.GitHubConstants.WEBHOOK_EVENT_HEADER;
+import static com.code.agent.infra.github.GitHubConstants.WEBHOOK_SIGNATURE_HEADER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/code/agent/application/listener/ReviewCommentListenersTest.java
+++ b/src/test/java/com/code/agent/application/listener/ReviewCommentListenersTest.java
@@ -12,7 +12,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewCommentListenersTest {

--- a/src/test/java/com/code/agent/application/listener/ReviewRequestedEventListenerTest.java
+++ b/src/test/java/com/code/agent/application/listener/ReviewRequestedEventListenerTest.java
@@ -17,7 +17,8 @@ import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewRequestedEventListenerTest {

--- a/src/test/java/com/code/agent/infra/ai/service/CodeReviewServiceTest.java
+++ b/src/test/java/com/code/agent/infra/ai/service/CodeReviewServiceTest.java
@@ -19,7 +19,12 @@ import reactor.test.StepVerifier;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CodeReviewServiceTest {


### PR DESCRIPTION
## Description
Remove wildcard imports from test files and replace them with explicit imports to improve code clarity and follow Java best practices.

## Type of Change
- [x] Refactoring

## Related Issues
Closes #50

## Changes Made
- Replace `import static org.mockito.Mockito.*;` with explicit imports in CodeReviewServiceTest.java
- Replace `import static org.mockito.Mockito.*;` with explicit imports in ReviewCommentListenersTest.java
- Replace `import static org.mockito.Mockito.*;` with explicit imports in ReviewRequestedEventListenerTest.java
- Replace `import static com.code.agent.infra.github.GitHubConstants.*;` with explicit imports in WebhookSignatureIntegrationTest.java

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (not required for this change)
- [x] No new warnings introduced
- [x] Tests pass locally
- [ ] ADR created/updated (not required for this change)